### PR TITLE
Fix url encoding bug in search

### DIFF
--- a/app/lib/search.ts
+++ b/app/lib/search.ts
@@ -68,7 +68,7 @@ export function urlWithTrackingParams({
 }: UrlWithTrackingParams) {
   let search = new URLSearchParams({
     ...extraParams,
-    q: encodeURIComponent(term),
+    q: term,
   }).toString();
 
   if (trackingParams) {


### PR DESCRIPTION
## Summary
- fix double encoding issue when building URLs with tracking params

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@shopify/oxygen-workers-types')*

------
https://chatgpt.com/codex/tasks/task_e_6860e3822ea08326b1d7b910475960ff